### PR TITLE
Add canonical/OG metadata and responsive image sizes for SEO and LCP

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,7 +1,17 @@
+import type { Metadata } from "next"
 import Image from "next/image"
 
 import { Footer } from "@/components/footer"
 import { Navbar } from "@/components/navbar"
+
+export const metadata: Metadata = {
+  title: "About",
+  description:
+    "Meet Dr. Swikriti Raniwala and learn about SWI Infinity's credentials, approach, and philosophy for safe, natural-looking aesthetic outcomes.",
+  alternates: {
+    canonical: "/about",
+  },
+}
 
 const credentials = [
   "MBBS - S.N. Medical College, Agra (2010-2016)",
@@ -58,6 +68,7 @@ export default function AboutPage() {
                     alt="Dr. Swikriti Raniwala, M.Ch. - Consultant Plastic, Reconstructive & Aesthetic Surgeon"
                     width={900}
                     height={1200}
+                    sizes="(max-width: 1024px) 100vw, 40vw"
                     className="h-full w-full object-cover"
                     priority
                   />

--- a/app/body/page.tsx
+++ b/app/body/page.tsx
@@ -5,6 +5,9 @@ export const metadata: Metadata = {
   title: "Body Contouring Procedures | SWI Infinity",
   description:
     "Explore advanced body contouring, sculpting, and augmentation procedures at SWI Infinity for your desired body shape.",
+  alternates: {
+    canonical: "/body",
+  },
 }
 
 // Force static generation - prevents client-side routing fallback

--- a/app/contact/layout.tsx
+++ b/app/contact/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Contact",
+  description:
+    "Contact SWI Infinity to schedule a consultation for hair, body, face, and skin procedures.",
+  alternates: {
+    canonical: "/contact",
+  },
+}
+
+export default function ContactLayout({ children }: { children: React.ReactNode }) {
+  return children
+}

--- a/app/face/page.tsx
+++ b/app/face/page.tsx
@@ -5,6 +5,9 @@ export const metadata: Metadata = {
   title: "Facial Procedures | SWI Infinity",
   description:
     "Explore advanced facial surgery and rejuvenation procedures for natural, harmonious results at SWI Infinity.",
+  alternates: {
+    canonical: "/face",
+  },
 }
 
 // Force static generation - prevents client-side routing fallback

--- a/app/hair/page.tsx
+++ b/app/hair/page.tsx
@@ -5,6 +5,9 @@ export const metadata: Metadata = {
   title: "Hair Procedures | SWI Infinity",
   description:
     "Explore advanced hair restoration procedures including transplant, PRP, and scalp treatments at SWI Infinity.",
+  alternates: {
+    canonical: "/hair",
+  },
 }
 
 // Force static generation - prevents client-side routing fallback

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,9 +19,39 @@ const montserrat = Montserrat({
 })
 
 export const metadata: Metadata = {
-  title: 'SWI Infinity | Premier Aesthetic & Plastic Surgery Clinic',
+  metadataBase: new URL('https://swiinfinity.com'),
+  title: {
+    default: 'SWI Infinity | Premier Aesthetic & Plastic Surgery Clinic',
+    template: '%s | SWI Infinity',
+  },
   description:
     'Where surgical excellence meets aesthetic harmony. 75 advanced procedures across hair restoration, body contouring, facial surgery, and skin treatments.',
+  alternates: {
+    canonical: '/',
+  },
+  openGraph: {
+    type: 'website',
+    url: '/',
+    title: 'SWI Infinity | Premier Aesthetic & Plastic Surgery Clinic',
+    description:
+      'Where surgical excellence meets aesthetic harmony. 75 advanced procedures across hair restoration, body contouring, facial surgery, and skin treatments.',
+    siteName: 'SWI Infinity',
+    images: [
+      {
+        url: '/images/hero-1.jpg',
+        width: 1200,
+        height: 630,
+        alt: 'SWI Infinity clinic hero image',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'SWI Infinity | Premier Aesthetic & Plastic Surgery Clinic',
+    description:
+      'Where surgical excellence meets aesthetic harmony. 75 advanced procedures across hair restoration, body contouring, facial surgery, and skin treatments.',
+    images: ['/images/hero-1.jpg'],
+  },
   icons: {
     icon: [
       {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next"
 import { Navbar } from "@/components/navbar"
 import { HeroSection } from "@/components/sections/hero"
 import { WelcomeSection } from "@/components/sections/welcome"
@@ -6,6 +7,12 @@ import { TestimonialsSection } from "@/components/sections/testimonials"
 import { FeaturesSection } from "@/components/sections/features"
 import { CtaSection } from "@/components/sections/cta"
 import { Footer } from "@/components/footer"
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: "/",
+  },
+}
 
 export default function HomePage() {
   return (

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,5 +1,15 @@
+import type { Metadata } from "next"
+
 import { Footer } from "@/components/footer"
 import { Navbar } from "@/components/navbar"
+
+export const metadata: Metadata = {
+  title: "Privacy Policy",
+  description: "Read how SWI Infinity collects, uses, and protects personal information.",
+  alternates: {
+    canonical: "/privacy",
+  },
+}
 
 export default function PrivacyPage() {
   return (

--- a/app/procedures/[slug]/page.tsx
+++ b/app/procedures/[slug]/page.tsx
@@ -28,12 +28,30 @@ export async function generateMetadata({
     return {
       title: "Procedure Not Found | SWI Infinity",
       description: "The requested procedure could not be found.",
+      alternates: {
+        canonical: "/procedures",
+      },
     }
   }
 
   return {
     title: procedure.seoTitle,
     description: procedure.seoDescription,
+    alternates: {
+      canonical: `/procedures/${procedure.slug}`,
+    },
+    openGraph: {
+      type: "article",
+      url: `/procedures/${procedure.slug}`,
+      title: procedure.seoTitle,
+      description: procedure.seoDescription,
+      images: [
+        {
+          url: procedure.imagePath,
+          alt: procedure.name,
+        },
+      ],
+    },
   }
 }
 
@@ -98,6 +116,7 @@ export default async function ProcedureDetailPage({ params }: ProcedureDetailPag
                 width={1600}
                 height={900}
                 priority
+                sizes="(max-width: 768px) 100vw, 1200px"
                 className="h-auto w-full object-cover"
               />
             </div>

--- a/app/procedures/page.tsx
+++ b/app/procedures/page.tsx
@@ -1,5 +1,15 @@
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import { procedures } from '@/lib/procedures';
+
+export const metadata: Metadata = {
+  title: 'All Procedures',
+  description:
+    'Browse all surgical and non-surgical aesthetic procedures offered at SWI Infinity.',
+  alternates: {
+    canonical: '/procedures',
+  },
+};
 
 export default function ProceduresPage() {
   return (

--- a/app/skin/page.tsx
+++ b/app/skin/page.tsx
@@ -5,6 +5,9 @@ export const metadata: Metadata = {
   title: "Skin Treatments | SWI Infinity",
   description:
     "Explore advanced skin treatments including lasers, injectables, and rejuvenation therapies at SWI Infinity.",
+  alternates: {
+    canonical: "/skin",
+  },
 }
 
 // Force static generation - prevents client-side routing fallback

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,5 +1,15 @@
+import type { Metadata } from "next"
+
 import { Footer } from "@/components/footer"
 import { Navbar } from "@/components/navbar"
+
+export const metadata: Metadata = {
+  title: "Terms of Service",
+  description: "Review SWI Infinity's website and service usage terms.",
+  alternates: {
+    canonical: "/terms",
+  },
+}
 
 export default function TermsPage() {
   return (

--- a/components/sections/hero.tsx
+++ b/components/sections/hero.tsx
@@ -61,6 +61,7 @@ export function HeroSection() {
             src={slide.image}
             alt={slide.title}
             fill
+            sizes="100vw"
             className="object-cover"
             priority={index === 0}
           />

--- a/components/sections/welcome.tsx
+++ b/components/sections/welcome.tsx
@@ -14,6 +14,7 @@ export function WelcomeSection() {
                 src="/images/about-clinic.jpg"
                 alt="SWI Infinity Clinic Interior"
                 fill
+                sizes="(max-width: 1024px) 100vw, 50vw"
                 className="object-cover"
               />
             </div>


### PR DESCRIPTION
### Motivation
- Provide consistent canonical and social metadata across the site to prevent duplicate metadata and improve social previews. 
- Improve LCP and responsive image delivery by giving `next/image` explicit `sizes` for above-the-fold images. 
- Ensure dynamic procedure pages expose per-page OpenGraph metadata so shared links render with proper titles/images. 

### Description
- Added a stronger global metadata baseline in `app/layout.tsx` including `metadataBase`, a title `template`/`default`, `alternates.canonical`, `openGraph` defaults and `twitter` card defaults. 
- Added route-level metadata (`title`, `description`, `alternates.canonical`) for home, `about`, `contact` (via `app/contact/layout.tsx`), `privacy`, `terms`, `procedures` index and category pages (`/hair`, `/skin`, `/face`, `/body`). 
- Enhanced dynamic procedure metadata in `app/procedures/[slug]/page.tsx` with per-slug `alternates.canonical` and `openGraph` (including image payload), and added a `sizes` hint to the procedure hero image. 
- Added `sizes` hints to key above-the-fold images: hero slides (`components/sections/hero.tsx`), welcome image (`components/sections/welcome.tsx`), and the about profile image (`app/about/page.tsx`) to help the browser pick appropriate srcset candidates. 

### Testing
- Ran `npm run build`; the build failed in this environment due to `next/font/google` failing to fetch Google Fonts during the Turbopack build (network restriction in CI-like environment). 
- Ran `npm run lint`; the linter failed because ESLint v9 expects a flat `eslint.config.*` file and the repository uses older `.eslintrc.*` format (no flat config present).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abbd0c8654832fa35f0435e6852eea)